### PR TITLE
Add Skipped marker message to tertiary filter

### DIFF
--- a/src/main/java/konstructs/api/messages/Filter.java
+++ b/src/main/java/konstructs/api/messages/Filter.java
@@ -46,7 +46,7 @@ import akka.actor.ActorRef;
  * @param <T> The contained message type of the filtered event
  */
 public abstract class Filter<T> implements Serializable {
-    private static ActorRef[] EMPTY_FILTER = {};
+    protected static ActorRef[] EMPTY_FILTER = {};
 
     private final ActorRef[] chain;
     private final T message;


### PR DESCRIPTION
- When skipping in the world phase, use the Skipped marker message to
  wrap the filter returned to the server to avoid the server running the
  next phase
- Make EMPTY_FILTER protected since it is now required by tertiary
  filter to implement the skip
